### PR TITLE
remove optional ISO-CERT

### DIFF
--- a/test/00_BCLD-BUILD.bats
+++ b/test/00_BCLD-BUILD.bats
@@ -112,7 +112,6 @@ img_size () {
     tag_check 'ISO-MOUNT'
     tag_check 'ISO-CHROOT'
     tag_check 'ISO-POSTCONF'
-    tag_check 'ISO-CERT'
     tag_check 'ISO-TWEAKS'
     tag_check 'ISO-INITRAMFS'
     tag_check 'ISO-REPO'

--- a/test/bcld.md5
+++ b/test/bcld.md5
@@ -112,7 +112,7 @@ eaebf4213b8a73ee8800b7c156e07188  ./script/bcld_vendor.sh
 5615ba273635885e12f2c97b32c6b4b4  ./script/rsyslogger.sh
 c3e0ce83bdf2d7ddf17002da8320b0b3  ./script/startup.sh
 d267254e779d5f15b28f8f79442f707d  ./script/usb_logger.sh
-475fbb196946809798513583f5317901  ./test/00_BCLD-BUILD.bats
+1c98709abb1b5a15a11c239dbe3f69f4  ./test/00_BCLD-BUILD.bats
 0b1d119254ad08f0c28a1975b28bbc2a  ./test/BCLD-BATS.sh
 1348c09b472f193682790b0fe9ae6792  ./test/SHELL-CHECK.sh
 05efb643572d1e799dea3af6021193e4  ./test/bcld_test.sh

--- a/test/md5sum
+++ b/test/md5sum
@@ -1,1 +1,1 @@
-397fafd4977b2a5a35821ae07f0fec99  ./test/bcld.md5
+d2833023d0080c986374a548e67e6f1b  ./test/bcld.md5


### PR DESCRIPTION
* Fix TagCheck
* Remove ISO-CERT since it's not used in Vendorless