### PR TITLE
Leviathan 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 ## 2024
 
 ## Oktober
-* `2024-10-11 17:21:26` : [OAC-1159] 
-    - Removing exports from [bcld-init](./config/bash/bcld-init) since they do not work
-    - Changed `BCLD_MACHINE_ID` to `BCLD_HOST_ID`, since the actual machine id is longer
+* `2024-10-11 17:21:26` : [OAC-1159] Changed `BCLD_MACHINE_ID` to `BCLD_HOST`, since the actual machine id is longer
 * `2024-10-11 15:05:44` : [OAC-1159]
     - Added Super key to `xmodmap` configuration
     - Applied name corrections in repository for capitalization errors...

--- a/test/bcld.md5
+++ b/test/bcld.md5
@@ -6,7 +6,7 @@ bb9cd8f6b404dc391601d1610b3518b2  ./.github/workflows/release.yml
 0f9bc2b595325394e775dcdb2f0164da  ./.github/workflows/unit-test.yml
 fe04418f518751b34909a21f6bd44c94  ./.gitignore
 ce2d9b29f5e16b1023375f232369f7ff  ./.gitmodules
-9eff7368b5d10dc0bf0c1b0c2bb00fe3  ./CHANGELOG.md
+71537e4713f9fa82d749e26348e6f768  ./CHANGELOG.md
 04aff3cce210e9c2a8f21df593f07b19  ./COPYING
 445e79b801abc6d9f0b1b5f78e8f8e88  ./Docker-builder.sh
 ef29c64bd35fec47b154096be5a4c7d0  ./IMG-builder.sh

--- a/test/md5sum
+++ b/test/md5sum
@@ -1,1 +1,1 @@
-9aaaf8847643b6d6269677baeba79341  ./test/bcld.md5
+a24a1f48fab06a66fad147f2e9370878  ./test/bcld.md5


### PR DESCRIPTION
* `2024-10-11 17:21:26` : [OAC-1159] 
    - Removing exports from [bcld-init](./config/bash/bcld-init) since they do not work
    - Changed `BCLD_MACHINE_ID` to `BCLD_HOST_ID`, since the actual machine id is longer
* `2024-10-11 15:05:44` : [OAC-1159]
    - Added Super key to `xmodmap` configuration
    - Applied name corrections in repository for capitalization errors...
    - Added new `BCLD_KEYMAPs` function in [bcld_test](./test/bcld_test.sh) for quick analysis of key map status
    - Added new output in [Xconfigure](./script/Xconfigure.sh) for `BCLD_VERBOSE`
    - Shorten [BCLD_KEYMAPs](./test/bcld_test.sh)
* `2024-10-11 13:36:42` : [OAC-1159] Found conflicts between `Xkbmap`, `xmodmap` and `xbindkeys` configurations
    - `xkbmap` : Will be used to disable system keys, (like TTY switching)
    - [xmodmap](./config/X11/xmodmap/.xmodmap) : Will be used to disable entire keys (like Alt and Meta)
    - [xbindkeys](./config/X11/xbindkeys/.xbindkeysrc) : Will be used to disable custom shortcuts (like closing browser tabs in web browsers)
* `2024-10-10 17:14:01` : [OAC-1159] Fix typo in [Xconfigure](./script/Xconfigure.sh) that broke the entire script and disabled kiosk mode
* `2024-10-08 11:07:12` : [OAC-1159] Updated [xbindkeys](./config/X11/xbindkeys/.xbindkeysrc) configuration